### PR TITLE
Pass args from tox to setup.py

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ skip_install = true
 setenv =
     COVERAGE_FILE={toxinidir}/.coverage.{envname}
 commands =
-    coverage run setup.py test
+    coverage run setup.py test {posargs}
 deps =
     pytest
     coverage


### PR DESCRIPTION
You should be able to use test filtering like this:
- `python setup.py test --addopts tests/test_connection.py`
- `tox -- --addopts tests/test_connection.py`