### PR TITLE
Check the future state before setting result

### DIFF
--- a/panoramisk/actions.py
+++ b/panoramisk/actions.py
@@ -85,7 +85,7 @@ class Action(utils.CaseInsensitiveDict):
     def add_message(self, message):
         self.responses.append(message)
         multi = self.multi
-        if self.completed:
+        if self.completed and not self.future.done():
             if multi and len(self.responses) > 1:
                 self.future.set_result(self.responses)
             elif not multi:

--- a/panoramisk/call_manager.py
+++ b/panoramisk/call_manager.py
@@ -36,7 +36,8 @@ class CallManager(manager.Manager):
         uniqueid = event.uniqueid.split('.', 1)[0]
         call = self.calls_queues[uniqueid]
         call.action_id = event.action_id
-        future.set_result(call)
+        if not future.done():
+            future.set_result(call)
 
     def send_originate(self, action):
         action['Async'] = 'true'


### PR DESCRIPTION
This prevent error when the future is canceled by another task. For example a timeout.