### PR TITLE
Queue action only when no response

### DIFF
--- a/panoramisk/actions.py
+++ b/panoramisk/actions.py
@@ -1,5 +1,9 @@
 import asyncio
+import logging
+
 from . import utils
+
+LOG = logging.getLogger(__name__)
 
 
 class Action(utils.CaseInsensitiveDict):

--- a/panoramisk/actions.py
+++ b/panoramisk/actions.py
@@ -1,9 +1,6 @@
 import asyncio
-import logging
 
 from . import utils
-
-LOG = logging.getLogger(__name__)
 
 
 class Action(utils.CaseInsensitiveDict):


### PR DESCRIPTION
For multi action when at least one response is received from
asterisk we do not queue the action for a resend when loosing
connection.

This fix originate being resent after disconection due to #54