### PR TITLE
Fix event listener example

### DIFF
--- a/examples/event_listener.py
+++ b/examples/event_listener.py
@@ -8,24 +8,24 @@ manager = Manager(loop=asyncio.get_event_loop(),
 
 
 @manager.register_event('*')
-def callback(event, manager):
-    if "FullyBooted" not in manager.event:
+def callback(manager, message):
+    if "FullyBooted" not in message.event:
         """This will print every event, but the FullyBooted events as these
         will continuously spam your screen"""
-        print(manager)
+        print(message)
 
 
 """
 # This will print NewChannel Events
 @manager.register_event('NewChannel')
-def callback(event, manager):
-    print(manager)
+def callback(manager, message):
+    print(message)
 
 
 # This will print Hangup Events
 @manager.register_event('Hangup')
-def callback(event, manager):
-    print(manager)
+def callback(manager, message):
+    print(message)
 """
 
 


### PR DESCRIPTION
In the example callback params were on the wrong places. According to
the documentation
(https://panoramisk.readthedocs.io/en/latest/manager.html#panoramisk.Manager.register_event)
the first argument should be manager and the second one should be the
event message, while in the example the first argument is called event
(while being actually manager) and the second one is called manager,
while actually being the event message.

This PR fixes that misleading example according to the documentation