### PR TITLE
Fix test dependencies for py3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #  -*- coding: utf-8 -*-
 import os
+import sys
 from setuptools import setup
 from setuptools import find_packages
 
@@ -8,7 +9,10 @@ version = '1.2.dev0'
 
 install_requires = []
 test_requires = [
-    'pytest', 'pytest-asyncio', 'coverage', 'coveralls'
+    'pytest',
+    'pytest-asyncio<0.6.0' if sys.version_info < (3, 5) else 'pytest-asyncio',
+    'coverage',
+    'coveralls',
 ]
 
 


### PR DESCRIPTION
According to changelog
(https://github.com/pytest-dev/pytest-asyncio#060-2017-05-28),
pytest-asyncio has dropped support for python versions earlier than 3.5
since 0.6.0 release. Thus CI builds will fail for tox env <= py3.4

This PR introduces an upper bound for pytest-asyncio dependency if
python version is less than 3.5