### PR TITLE
Fix multiple callback call with the same pattern

### DIFF
--- a/panoramisk/manager.py
+++ b/panoramisk/manager.py
@@ -214,8 +214,9 @@ class Manager:
             ...     print(manager, event)
         """
         def _register_event(callback):
-            self.patterns.append((pattern,
-                                 re.compile(fnmatch.translate(pattern))))
+            if not self.callbacks[pattern]:
+                self.patterns.append((pattern,
+                                     re.compile(fnmatch.translate(pattern))))
             self.callbacks[pattern].append(callback)
             return callback
         if callback is not None:


### PR DESCRIPTION
If add multiple callbacks with the same pattern, each will be call multiple times.
For example: 
```python
manager.register_event('FullyBooted', cb)
```

in `manager.py`:
```python
    def __init__(self, **config):
        # ...
        self.register_event('FullyBooted', self.send_awaiting_actions)
```

```
2017-12-22 18:12:59,800 - panoramisk.manager - INFO - Sending awaiting actions
2017-12-22 18:12:59,800 - root - INFO - {
    "Event": "FullyBooted",
    "Privilege": "system,all",
    "Status": "Fully Booted",
    "content": ""
}
2017-12-22 18:12:59,800 - panoramisk.manager - INFO - Sending awaiting actions
2017-12-22 18:12:59,800 - root - INFO - {
    "Event": "FullyBooted",
    "Privilege": "system,all",
    "Status": "Fully Booted",
    "content": ""
}

```

This PR fix it