### PR TITLE
Fix "KeyError: '<unknown>'"

### DIFF
--- a/panoramisk/call_manager.py
+++ b/panoramisk/call_manager.py
@@ -38,7 +38,6 @@ class CallManager(manager.Manager):
             call = self.calls_queues[uniqueid]
         else:
             call = Call(uniqueid)
-        
         call.action_id = event.action_id
         if not future.done():
             future.set_result(call)

--- a/panoramisk/call_manager.py
+++ b/panoramisk/call_manager.py
@@ -34,7 +34,11 @@ class CallManager(manager.Manager):
         else:
             event = res
         uniqueid = event.uniqueid.split('.', 1)[0]
-        call = self.calls_queues[uniqueid]
+        if uniqueid in self.calls_queues:
+            call = self.calls_queues[uniqueid]
+        else:
+            call = Call(uniqueid)
+        
         call.action_id = event.action_id
         if not future.done():
             future.set_result(call)


### PR DESCRIPTION
When Originate response return Failure, the uniqueid is not be generate it by Asterisk

```
Exception in callback CallManager.set_result(<Future pendi...sk._wakeup()]>)(<Future finis... content=''>]>)
handle: <Handle CallManager.set_result(<Future pendi...sk._wakeup()]>)(<Future finis... content=''>]>)>
Traceback (most recent call last):
  File "/usr/lib64/python3.4/asyncio/events.py", line 125, in _run
    self._callback(*self._args)
  File "/usr/lib/python3.4/site-packages/panoramisk/call_manager.py", line 37, in set_result
    call = self.calls_queues[uniqueid]
KeyError: '<unknown>'
```