### PR TITLE
Fixed memory leak for action QueueAdd

### DIFF
--- a/panoramisk/actions.py
+++ b/panoramisk/actions.py
@@ -62,8 +62,6 @@ class Action(utils.CaseInsensitiveDict):
             return True
         elif 'will follow' in msg:
             return True
-        elif msg.startswith('added') and msg.endswith('to queue'):
-            return True
         elif msg.endswith('successfully queued') and self.async != 'false':
             return True
         elif self.as_list:


### PR DESCRIPTION
Asterisk does not provide property **ActionID** for event **QueueMemberAdded**.
So, action **QueueAdd** with _multi_ is True will be always in awaiting state in the asyncio loop.