### PR TITLE
Check 100 Trying... response from FastAGI and wait for next result

### DIFF
--- a/panoramisk/utils.py
+++ b/panoramisk/utils.py
@@ -20,6 +20,8 @@ def parse_agi_result(line):
 
     AGI Result examples::
 
+        100 result=0 Trying...
+
         200 result=0
 
         200 result=-1
@@ -59,7 +61,9 @@ def agi_code_check(code=None, response=None, line=None):
     code = int(code)
     response = response or ""
     result = {'status_code': code, 'result': ('', ''), 'msg': ''}
-    if code == 200:
+    if code == 100:
+        result['msg'] = line
+    elif code == 200:
         for key, value, data in re_kv.findall(response):
             result[key] = (value, data)
             # If user hangs up... we get 'hangup' in the data
@@ -80,6 +84,7 @@ def agi_code_check(code=None, response=None, line=None):
     else:
         # Unhandled code or undefined response
         result['error'] = 'AGIUnknownError'
+        result['msg'] = line
     return result
 
 

--- a/tests/test_fast_agi.py
+++ b/tests/test_fast_agi.py
@@ -45,6 +45,7 @@ def fake_asterisk_client(loop, unused_tcp_port):
     writer.write(FAST_AGI_PAYLOAD)
     # read it back
     msg_back = yield from reader.readline()
+    writer.write(b'100 Trying...\n')
     writer.write(b'200 result=0\n')
     writer.close()
     return msg_back


### PR DESCRIPTION
This is my fix for #75.

I also took the liberty of slightly changing `parse_agi_result`, so it will always try to parse the response, not just if the response was successful. This should make it easier to diagnose anything else lacking in the current implementation, because you can actually see what Asterisk returned.