### PR TITLE
Check if status_code is present in agi_result

### DIFF
--- a/panoramisk/fast_agi.py
+++ b/panoramisk/fast_agi.py
@@ -39,7 +39,7 @@ class Request:
 
         agi_result = yield from self._read_result()
         # If Asterisk returns `100 Trying...`, wait for next the response.
-        while agi_result['status_code'] == 100:
+        while 'status_code' in agi_result and agi_result['status_code'] == 100:
             agi_result = yield from self._read_result()
 
         # when we got AGIUsageError the following line contains some indication

--- a/panoramisk/fast_agi.py
+++ b/panoramisk/fast_agi.py
@@ -39,7 +39,7 @@ class Request:
 
         agi_result = yield from self._read_result()
         # If Asterisk returns `100 Trying...`, wait for next the response.
-        while 'status_code' in agi_result and agi_result['status_code'] == 100:
+        while agi_result.get('status_code') == 100:
             agi_result = yield from self._read_result()
 
         # when we got AGIUsageError the following line contains some indication


### PR DESCRIPTION
When the caller hangs the call, agi_result doesn't contain a status_code, because of this line: https://github.com/gawel/panoramisk/blob/a4402ef9a46b235de08b61e32c630d86e1aff0eb/panoramisk/utils.py#L43
Ping @HansAdema because it changes a little bit the 100 handling you have implemented with the PR #75