### PR TITLE
Originate async fix

### DIFF
--- a/panoramisk/actions.py
+++ b/panoramisk/actions.py
@@ -66,7 +66,7 @@ class Action(utils.CaseInsensitiveDict):
             return True
         elif msg.startswith('added') and msg.endswith('to queue'):
             return True
-        elif msg.endswith('successfully queued') and self['async'] != 'false':
+        elif msg.endswith('successfully queued') and self['async'] == 'false':
             return True
         return False
 

--- a/panoramisk/actions.py
+++ b/panoramisk/actions.py
@@ -66,8 +66,6 @@ class Action(utils.CaseInsensitiveDict):
             return True
         elif msg.startswith('added') and msg.endswith('to queue'):
             return True
-        elif msg.endswith('successfully queued') and self['async'] == 'false':
-            return True
         return False
 
     @property


### PR DESCRIPTION
There is a bug in Originate async - condition error.
send_action with Originate with ``async=true``  did not return as it is expected and waited until OriginateResponse event was generated to return it in list.
Here is the fix.