### PR TITLE
Added ability to optionally raise exceptions on AGI errors

### DIFF
--- a/panoramisk/exceptions.py
+++ b/panoramisk/exceptions.py
@@ -1,0 +1,47 @@
+class AGIException(Exception):
+    """The base exception for all AGI-related exceptions.
+    """
+
+    def __init__(self, message, items):
+        Exception.__init__(self, message)
+        self.items = items  # A dictionary containing data received from Asterisk, if any
+
+
+class AGIResultHangup(AGIException):
+    """Indicates that Asterisk received a hangup event.
+    """
+
+
+class AGIError(AGIException):
+    """The base exception for all AGI errors resulting from improper usage or Asterisk bug.
+    """
+
+
+class AGINoResultError(AGIError):
+    """Indicates that Asterisk did not return a 'result' parameter in a 200 response.
+    """
+
+
+class AGIUnknownError(AGIError):
+    """Indicates that an unknown response is received from Asterisk.
+    """
+
+
+class AGIAppError(AGIError):
+    """Indicates that an Asterisk application failed to execute.
+    """
+
+
+class AGIDeadChannelError(AGIError):
+    """Indicates that a command was issued on a channel that can no longer process it.
+    """
+
+
+class AGIInvalidCommand(AGIError):
+    """Indicates that a request made to Asterisk was not understood.
+    """
+
+
+class AGIUsageError(AGIError):
+    """Indicates that a request made to Asterisk was sent with invalid syntax.
+    """

--- a/tests/test_fast_agi.py
+++ b/tests/test_fast_agi.py
@@ -1,10 +1,37 @@
 import asyncio
 import pytest
+from panoramisk.exceptions import AGIAppError
 from panoramisk.fast_agi import Application
 
 FAST_AGI_PAYLOAD = b'''agi_network: yes
 agi_network_script: call_waiting
 agi_request: agi://127.0.0.1:4574/call_waiting
+agi_channel: SIP/xxxxxx-00000000
+agi_language: en_US
+agi_type: SIP
+agi_uniqueid: 1437920906.0
+agi_version: asterisk
+agi_callerid: 201
+agi_calleridname: user 201
+agi_callingpres: 0
+agi_callingani2: 0
+agi_callington: 0
+agi_callingtns: 0
+agi_dnid: 9011
+agi_rdnis: unknown
+agi_context: default
+agi_extension: 9011
+agi_priority: 2
+agi_enhanced: 0.0
+agi_accountcode: default
+agi_threadid: -1260881040
+agi_arg_1: answered
+
+'''
+
+FAST_AGI_ERROR_PAYLOAD = b'''agi_network: yes
+agi_network_script: invalid
+agi_request: agi://127.0.0.1:4574/invalid
 agi_channel: SIP/xxxxxx-00000000
 agi_language: en_US
 agi_type: SIP
@@ -36,17 +63,29 @@ async def call_waiting(request):
     assert r == v
 
 
-async def fake_asterisk_client(loop, unused_tcp_port):
+async def invalid(request):
+    with pytest.raises(AGIAppError) as excinfo:
+        await request.send_command('EXEC Dial something')
+    assert excinfo.result == {'msg': '', 'status_code': 200, 'result': ('-1', '')}
+
+
+async def fake_asterisk_client(unused_tcp_port, err=False):
     reader, writer = await asyncio.open_connection(
         '127.0.0.1', unused_tcp_port)
     # send headers
-    writer.write(FAST_AGI_PAYLOAD)
+    if err:
+        writer.write(FAST_AGI_ERROR_PAYLOAD)
+    else:
+        writer.write(FAST_AGI_PAYLOAD)
     # read it back
-    msg_back = await reader.readline()
-    writer.write(b'100 Trying...\n')
-    writer.write(b'200 result=0\n')
+    msg = await reader.readline()
+    if msg == b'ANSWER\n':
+        writer.write(b'100 Trying...\n')
+        writer.write(b'200 result=0\n')
+    elif msg == b'EXEC Dial something\n':
+        writer.write(b'200 result=-1\n')
     writer.close()
-    return msg_back
+    return msg
 
 
 @pytest.mark.asyncio
@@ -57,9 +96,23 @@ async def test_fast_agi_application(event_loop, unused_tcp_port):
     server = await asyncio.start_server(fa_app.handler, '127.0.0.1',
                                         unused_tcp_port)
 
-    msg_back = await fake_asterisk_client(event_loop,
-                                          unused_tcp_port)
-    assert b'ANSWER\n' == msg_back
+    msg_back = await fake_asterisk_client(unused_tcp_port)
+    assert msg_back == b'ANSWER\n'
+
+    server.close()
+    await server.wait_closed()
+    await asyncio.sleep(1)  # Wait the end of endpoint
+
+
+@pytest.mark.asyncio
+async def test_fast_agi_application_error(event_loop, unused_tcp_port):
+    fa_app = Application(loop=event_loop, raise_on_error=True)
+    fa_app.add_route('invalid', invalid)
+
+    server = await asyncio.start_server(fa_app.handler, '127.0.0.1',
+                                        unused_tcp_port)
+
+    await fake_asterisk_client(unused_tcp_port, err=True)
 
     server.close()
     await server.wait_closed()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,27 +1,39 @@
 from panoramisk import utils
+from panoramisk.exceptions import AGIException
 
 
 def test_parse_agi_valid_result():
-    res = utils.parse_agi_result('200 result=0')
+    res = try_parse_agi_result('200 result=0')
     assert res == {'msg': '', 'result': ('0', ''), 'status_code': 200}
 
-    res = utils.parse_agi_result('200 result=1')
+    res = try_parse_agi_result('200 result=1')
     assert res == {'msg': '', 'result': ('1', ''), 'status_code': 200}
 
-    res = utils.parse_agi_result('200 result=1234')
+    res = try_parse_agi_result('200 result=1234')
     assert res == {'msg': '', 'result': ('1234', ''), 'status_code': 200}
 
-    res = utils.parse_agi_result('200 result= (timeout)')
-    assert res == {'msg': '', 'result': ('', ''), 'status_code': 200}
+    res = try_parse_agi_result('200 result= (timeout)')
+    assert res == {'msg': '', 'result': ('', 'timeout'), 'status_code': 200}
 
 
 def test_parse_agi_invalid_result():
-    res = utils.parse_agi_result('510 Invalid or unknown command')
-    assert res == {'msg': '', 'result': ('', ''),
+    res = try_parse_agi_result('510 Invalid or unknown command')
+    assert res == {'msg': '510 Invalid or unknown command',
                    'error': 'AGIInvalidCommand',
                    'status_code': 510}
 
-    res = utils.parse_agi_result('520 Use this')
-    assert res == {'msg': '520 Use this', 'result': ('', ''),
+    res = try_parse_agi_result('520 Use this')
+    assert res == {'msg': '520 Use this',
                    'error': 'AGIUsageError',
                    'status_code': 520}
+
+
+def try_parse_agi_result(result):
+    try:
+        res = utils.parse_agi_result(result)
+    except AGIException as err:
+        res = err.items
+        res['error'] = err.__class__.__name__
+        res['msg'] = err.args[0]
+
+    return res


### PR DESCRIPTION
FastAGI application can now be made to raise exceptions by providing raise_on_error=True constructor param. I added a few unit tests and also tested in production. While implementing this, I felt compelled to make a couple of tweaks:

- I slightly modified key/value regex. As it is, in a response "200 result= (timeout)", timeout part is lost. While this appears to be by design (looking at unit tests), it does not make sense to hide data from the user.
- Currently, an empty result is included in every response, which also doesn't make sense. Error responses should not contain a result (and some already don't, so there is inconsistency). I have removed the result from all error responses. There is absolutely no reason to check for it, so it shouldn't break anything.
- On the other hand, a 200 response MUST contain a result, so including an empty one by default is potentially misleading. A missing result indicates an Asterisk bug, so I have introduced a new exception (AGINoResultError) for this unlikely case.