### PR TITLE
(feat) fast agi: decode errors

### DIFF
--- a/panoramisk/fast_agi.py
+++ b/panoramisk/fast_agi.py
@@ -79,9 +79,10 @@ class Application(dict):
 
     buf_size = 100
 
-    def __init__(self, default_encoding='utf-8', loop=None, raise_on_error=False):
+    def __init__(self, default_encoding='utf-8', loop=None, raise_on_error=False, decode_errors=None):
         super(Application, self).__init__()
         self.default_encoding = default_encoding
+        self.decode_errors = decode_errors
         if loop is None:
             loop = asyncio.get_event_loop()
         self.loop = loop
@@ -159,7 +160,7 @@ class Application(dict):
         buffer = b''
         while b'\n\n' not in buffer:
             buffer += await reader.read(self.buf_size)
-        lines = buffer[:-2].decode(self.default_encoding).split('\n')
+        lines = buffer[:-2].decode(self.default_encoding, errors=self.decode_errors).split('\n')
         headers = OrderedDict([
             line.split(': ', 1) for line in lines if ': ' in line
         ])


### PR DESCRIPTION
Hello!

Sometimes, asterisk can pull truncated data to agi request. Something like this:

`b'agi_network: yes\nagi_network_script: call_income\nagi_request: agi://127.0.0.1:4574/call_income\nagi_channel: SIP/*****-00011487\nagi_language: en\nagi_type: SIP\nagi_uniqueid: 1648407597.170145\nagi_version: 16.17.0\nagi_callerid: ****\nagi_calleridname: \xd0\x90\xd0\xbb\xd0\xb5\xd0\xba\xd1\x81\xd0\xb5\xd0\xb9, Volkswagen Passat, K129\xd0\nagi_callingpres: 0\nagi_callingani2: 0\nagi_callington: 0\nagi_callingtns: 0\nagi_dnid: 74991166525\nagi_rdnis: *****\nagi_context: macro-dial-ringall-predial-hook\nagi_extension: s\nagi_priority: 1\nagi_enhanced: 0.0\nagi_accountcode: \nagi_threadid: 140011921778432\nagi_arg_1:  302-303-304-306-307-308-309-310-311-312-313-314-315-320-321-323-329-339-340-341-342-318-346-347-348-349-10091-331-350'`

So, if we try just to decode — it throws `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd0 in position 310: invalid continuation byte`.

Will be nice to pass decode errors argument like `.decode("utf-8", errors="ignore")` to decode pass much well (than exception):

`'agi_network: yes\nagi_network_script: call_income\nagi_request: agi://127.0.0.1:4574/call_income\nagi_channel: SIP/*****-00011487\nagi_language: en\nagi_type: SIP\nagi_uniqueid: 1648407597.170145\nagi_version: 16.17.0\nagi_callerid: ****\nagi_calleridname: Алексей, Volkswagen Passat, K129\nagi_callingpres: 0\nagi_callingani2: 0\nagi_callington: 0\nagi_callingtns: 0\nagi_dnid: 74991166525\nagi_rdnis: *****\nagi_context: macro-dial-ringall-predial-hook\nagi_extension: s\nagi_priority: 1\nagi_enhanced: 0.0\nagi_accountcode: \nagi_threadid: 140011921778432\nagi_arg_1:  302-303-304'`

I add one more parameter to avoid this situation:

`fast_agi.Application(decode_errors="ignore")`

- May be AMI connection need this extension too. I use only AGI. If you find this PR helpfull I can add this lines to AMI.
- May be it can be "ignore" by default.

Thank you for your library!