### PR TITLE
AMI: fix QueueAdd multi message wrong detect

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3
@@ -24,4 +24,4 @@ jobs:
         run: tox -e py
       - name: Run flake8 / docs
         run: tox -e flake8,docs
-        if: "matrix.python == '3.10' || matrix.python == '3.11'"
+        if: "matrix.python == '3.10' || matrix.python == '3.11' || matrix.python == '3.12'"

--- a/panoramisk/actions.py
+++ b/panoramisk/actions.py
@@ -79,6 +79,8 @@ class Action(utils.CaseInsensitiveDict, asyncio.Future):
             return True
         elif 'will follow' in msg:
             return True
+        elif msg == 'added interface to queue':
+            return False
         elif msg.startswith('added') and msg.endswith('to queue'):
             return True
         elif msg.endswith('successfully queued') and self['async'] != 'false':

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Communications :: Telephony',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/tests/fixtures/queue_add.yaml
+++ b/tests/fixtures/queue_add.yaml
@@ -1,0 +1,5 @@
+Response: Success
+ActionID: action/transaction_uid/1/1
+Message: Added interface to queue
+
+

--- a/tests/test_manager_with_fixtures.py
+++ b/tests/test_manager_with_fixtures.py
@@ -54,6 +54,15 @@ def test_queue_status(manager):
     assert len(responses) == 9
 
 
+def test_queue_add(manager):
+    manager = manager(stream='queue_add.yaml')
+    future = manager.send_action({'Action': 'QueueAdd',
+                                  'Queue': 'xxxxxxxxxxxxxxxx-tous',
+                                  'Interface': 'SIP/000000'})
+    responses = future.result()
+    assert len(responses) == 4
+
+
 def test_pjsip_show_endpoint(manager):
     manager = manager(stream='pjsip_show_endpoint.yaml')
     future = manager.send_action({'Action': 'PJSIPShowEndpoint',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,flake8,docs
+envlist = py37,py38,py39,py310,py311,py312,flake8,docs
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
Due to the specifics of the library and AMI, many users do not receive a response QueueAdd, although other actions such as QueueRemove and others work fine. Of course, you can add a parameter like as_list=False, but it's wrong when the same type of actions work differently. For example #54 and #92